### PR TITLE
Replace go get with go mod download in v2ray-sn build script

### DIFF
--- a/Other/v2ray-sn/build.ps1
+++ b/Other/v2ray-sn/build.ps1
@@ -23,7 +23,7 @@ $Env:GOROOT_FINAL='/usr'
 
 $Env:GOOS='windows'
 $Env:GOARCH='amd64'
-go get -u ./...
+go mod download
 go mod tidy
 go build -a -trimpath -asmflags '-s -w' -ldflags '-s -w -buildid=' -o '..\..\release\v2ray-sn.exe' '.\main'
 exit $lastExitCode


### PR DESCRIPTION
## Summary
- Replace `go get -u` with `go mod download` to build against pinned modules

## Testing
- `pwsh Other/v2ray-sn/build.ps1` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_68b509ae3c408322b2e4d27eae60e892