### PR TITLE
fix: avoid module upgrade for v2ray-sn

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/setup-go@v3
         if: steps.check_other.outputs.files_exists == 'false'
         with:
-          go-version: '1.18.x'
+          go-version: '1.20.x'
 
       - name: Setup C++
         uses: msys2/setup-msys2@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/setup-go@v3
         if: steps.check_other.outputs.files_exists == 'false'
         with:
-          go-version: '1.18.x'
+          go-version: '1.20.x'
 
       - name: Setup C++
         uses: msys2/setup-msys2@v2

--- a/Other/v2ray-sn/build.ps1
+++ b/Other/v2ray-sn/build.ps1
@@ -24,6 +24,5 @@ $Env:GOROOT_FINAL='/usr'
 $Env:GOOS='windows'
 $Env:GOARCH='amd64'
 go mod download
-go mod tidy
 go build -a -trimpath -asmflags '-s -w' -ldflags '-s -w -buildid=' -o '..\..\release\v2ray-sn.exe' '.\main'
 exit $lastExitCode


### PR DESCRIPTION
## Summary
- prevent v2ray-sn build script from upgrading modules
- pin Go version to 1.20 in CI workflows

## Testing
- `dotnet test` *(fails: command not found - dotnet not installed)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b51094955483228b723af77c4a8300