### PR TITLE
fix: build v2ray-sn with Go 1.18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/setup-go@v3
         if: steps.check_other.outputs.files_exists == 'false'
         with:
-          go-version: '1.18.x'
+          go-version: '1.18'
 
       - name: Setup C++
         uses: msys2/setup-msys2@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/setup-go@v3
         if: steps.check_other.outputs.files_exists == 'false'
         with:
-          go-version: '1.18.x'
+          go-version: '1.18'
 
       - name: Setup C++
         uses: msys2/setup-msys2@v2

--- a/Other/v2ray-sn/build.ps1
+++ b/Other/v2ray-sn/build.ps1
@@ -1,6 +1,6 @@
 Set-Location (Split-Path $MyInvocation.MyCommand.Path -Parent)
 
-git clone https://github.com/SagerNet/v2ray-core.git -b 'v5.0.16' src
+git clone https://github.com/SagerNet/v2ray-core.git -b 'v5.0.3' src
 if ( -Not $? ) {
     exit $lastExitCode
 }
@@ -24,6 +24,8 @@ $Env:GOROOT_FINAL='/usr'
 $Env:GOOS='windows'
 $Env:GOARCH='amd64'
 go mod download
-go mod tidy
+go get github.com/Dreamacro/clash/transport/simple-obfs@v1.8.0
+go get github.com/Dreamacro/clash/transport/ssr/obfs@v1.8.0
+go get github.com/Dreamacro/clash/transport/ssr/protocol@v1.8.0
 go build -a -trimpath -asmflags '-s -w' -ldflags '-s -w -buildid=' -o '..\..\release\v2ray-sn.exe' '.\main'
 exit $lastExitCode


### PR DESCRIPTION
## Summary
- clone v2ray-core v5.0.3 and add plugin dependencies explicitly
- set Go version to 1.18 in CI workflows

## Testing
- `dotnet test` *(command not found: dotnet)*
- `sudo apt-get install -y dotnet-sdk-7.0` *(Unable to locate package)*
- `pwsh Other/v2ray-sn/build.ps1` *(command not found: pwsh)*
- `sudo apt-get install -y powershell` *(Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b51094955483228b723af77c4a8300