### PR TITLE
fix: update quic-go for go1.18

### DIFF
--- a/Other/v2ray-sn/build.ps1
+++ b/Other/v2ray-sn/build.ps1
@@ -24,6 +24,7 @@ $Env:GOROOT_FINAL='/usr'
 $Env:GOOS='windows'
 $Env:GOARCH='amd64'
 go mod download
+go get github.com/lucas-clemente/quic-go@v0.31.0
 go get github.com/Dreamacro/clash/transport/simple-obfs@v1.8.0
 go get github.com/Dreamacro/clash/transport/ssr/obfs@v1.8.0
 go get github.com/Dreamacro/clash/transport/ssr/protocol@v1.8.0


### PR DESCRIPTION
## Summary
- ensure v2ray-sn build uses a quic-go version that supports Go 1.18+

## Testing
- `pwsh Other/v2ray-sn/build.ps1` *(fails: command not found: pwsh)*

------
https://chatgpt.com/codex/tasks/task_e_68b558b104a483229b8027b6fe91dfcb