### PR TITLE
fix: update quic-go for go1.18

### DIFF
--- a/Other/v2ray-sn/build.ps1
+++ b/Other/v2ray-sn/build.ps1
@@ -24,7 +24,7 @@ $Env:GOROOT_FINAL='/usr'
 $Env:GOOS='windows'
 $Env:GOARCH='amd64'
 go mod download
-go get github.com/lucas-clemente/quic-go@v0.31.0
+go get github.com/lucas-clemente/quic-go@v0.25.0
 go get github.com/Dreamacro/clash/transport/simple-obfs@v1.8.0
 go get github.com/Dreamacro/clash/transport/ssr/obfs@v1.8.0
 go get github.com/Dreamacro/clash/transport/ssr/protocol@v1.8.0

--- a/Other/v2ray-sn/build.ps1
+++ b/Other/v2ray-sn/build.ps1
@@ -24,8 +24,10 @@ $Env:GOROOT_FINAL='/usr'
 $Env:GOOS='windows'
 $Env:GOARCH='amd64'
 go mod download
+go get github.com/lucas-clemente/quic-go@v0.31.0
 go get github.com/Dreamacro/clash/transport/simple-obfs@v1.8.0
 go get github.com/Dreamacro/clash/transport/ssr/obfs@v1.8.0
 go get github.com/Dreamacro/clash/transport/ssr/protocol@v1.8.0
+go mod tidy
 go build -a -trimpath -asmflags '-s -w' -ldflags '-s -w -buildid=' -o '..\..\release\v2ray-sn.exe' '.\main'
 exit $lastExitCode


### PR DESCRIPTION
## Summary
- ensure v2ray-sn build uses a quic-go version that supports Go 1.18+
- run `go mod tidy` in v2ray-sn build script to populate missing module checksums

## Testing
- `pwsh Other/v2ray-sn/build.ps1` *(fails: command not found: pwsh)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_68b558b104a483229b8027b6fe91dfcb