### PR TITLE
fix: update v2ray-sn build for go1.18

### DIFF
--- a/Netch/Controllers/Guard.cs
+++ b/Netch/Controllers/Guard.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Text;
+using Microsoft.VisualStudio.Threading;
 using Netch.Enums;
 using Netch.Models;
 using Netch.Utils;

--- a/Netch/Interops/RouteHelper.cs
+++ b/Netch/Interops/RouteHelper.cs
@@ -1,5 +1,6 @@
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using Windows.Win32.Foundation;
 using Windows.Win32.Networking.WinSock;
 using Windows.Win32.NetworkManagement.IpHelper;
@@ -18,6 +19,7 @@ public static unsafe class RouteHelper
     [DllImport("RouteHelper.bin", CallingConvention = CallingConvention.Cdecl)]
     public static extern bool CreateUnicastIP(AddressFamily inet, string address, byte cidr, ulong index);
 
+    [SupportedOSPlatform("windows8.1")]
     public static bool CreateUnicastIPCS(AddressFamily inet, string address, byte cidr, ulong index)
     {
         MIB_UNICASTIPADDRESS_ROW addr;

--- a/Netch/Utils/PortHelper.cs
+++ b/Netch/Utils/PortHelper.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using Windows.Win32;
 using Windows.Win32.NetworkManagement.IpHelper;
 using Netch.Models;
@@ -28,6 +29,7 @@ public static class PortHelper
         }
     }
 
+    [SupportedOSPlatform("windows8.1")]
     internal static IEnumerable<Process> GetProcessByUsedTcpPort(ushort port, AddressFamily inet = AddressFamily.InterNetwork)
     {
         if (port == 0)

--- a/Other/v2ray-sn/build.ps1
+++ b/Other/v2ray-sn/build.ps1
@@ -6,11 +6,9 @@ if ( -Not $? ) {
 }
 Set-Location src
 
-# Download SSR plugin
-Invoke-WebRequest -Uri 'https://gist.githubusercontent.com/H1JK/b3165a99b635dcc06101690e4c43b5fd/raw/691b471f3b395a949d03a3d064d93d319d4997b7/ssr.go' -OutFile '.\proxy\shadowsocks\plugin\self\ssr.go'
-
-# Download Simple-Obfs plugin
-Invoke-WebRequest -Uri 'https://gist.githubusercontent.com/H1JK/b3165a99b635dcc06101690e4c43b5fd/raw/691b471f3b395a949d03a3d064d93d319d4997b7/obfs.go' -OutFile '.\proxy\shadowsocks\plugin\self\obfs.go'
+# Add SSR and Simple-Obfs plugins
+Copy-Item '..\ssr.go' '.\proxy\shadowsocks\plugin\self\ssr.go'
+Copy-Item '..\obfs.go' '.\proxy\shadowsocks\plugin\self\obfs.go'
 
 # Enable ReadV (Use old ReadV code)
 Remove-Item '.\common\buf\io.go'
@@ -24,8 +22,10 @@ $Env:GOROOT_FINAL='/usr'
 $Env:GOOS='windows'
 $Env:GOARCH='amd64'
 go mod download
+go get github.com/lucas-clemente/quic-go@v0.31.0
 go get github.com/Dreamacro/clash/transport/simple-obfs@v1.8.0
 go get github.com/Dreamacro/clash/transport/ssr/obfs@v1.8.0
 go get github.com/Dreamacro/clash/transport/ssr/protocol@v1.8.0
+go mod tidy
 go build -a -trimpath -asmflags '-s -w' -ldflags '-s -w -buildid=' -o '..\..\release\v2ray-sn.exe' '.\main'
 exit $lastExitCode

--- a/Other/v2ray-sn/build.ps1
+++ b/Other/v2ray-sn/build.ps1
@@ -16,6 +16,9 @@ Remove-Item '.\common\buf\readv_reader.go'
 Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/SagerNet/v2ray-core/2711fd1/common/buf/io.go' -OutFile '.\common\buf\io.go'
 Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/SagerNet/v2ray-core/2711fd1/common/buf/readv_reader.go' -OutFile '.\common\buf\readv_reader.go'
 
+# Patch core for quic-go v0.31 API changes
+git apply '..\quic-conn.patch'
+
 $Env:CGO_ENABLED='0'
 $Env:GOROOT_FINAL='/usr'
 

--- a/Other/v2ray-sn/obfs.go
+++ b/Other/v2ray-sn/obfs.go
@@ -1,0 +1,65 @@
+package self
+
+// Modified from: https://github.com/SagerNet/LibSagerNetCore/blob/main/obfs.go
+// License: GPLv3
+
+import (
+	"github.com/Dreamacro/clash/transport/simple-obfs"
+	"github.com/v2fly/v2ray-core/v5/proxy/shadowsocks"
+	"github.com/v2fly/v2ray-core/v5/transport/internet"
+)
+
+var _ shadowsocks.StreamPlugin = (*obfsLocalPlugin)(nil)
+
+func init() {
+	shadowsocks.RegisterPlugin("obfs-local", func() shadowsocks.SIP003Plugin {
+		return new(obfsLocalPlugin)
+	})
+}
+
+type obfsLocalPlugin struct {
+	tls  bool
+	host string
+	port string
+}
+
+func (p *obfsLocalPlugin) Init(_ string, _ string, _ string, remotePort string, pluginOpts string, _ []string, _ *shadowsocks.MemoryAccount) error {
+	options, err := ParsePluginOptions(pluginOpts)
+	if err != nil {
+		return newError("obfs-local: failed to parse plugin options").Base(err)
+	}
+
+	mode := "http"
+
+	if s, ok := options.Get("obfs"); ok {
+		mode = s
+	}
+
+	if s, ok := options.Get("obfs-host"); ok {
+		p.host = s
+	}
+
+	switch mode {
+	case "http":
+	case "tls":
+		p.tls = true
+	default:
+		return newError("unknown obfs mode ", mode)
+	}
+
+	p.port = remotePort
+
+	return nil
+}
+
+func (p *obfsLocalPlugin) StreamConn(connection internet.Connection) internet.Connection {
+	if !p.tls {
+		return obfs.NewHTTPObfs(connection, p.host, p.port)
+	} else {
+		return obfs.NewTLSObfs(connection, p.host)
+	}
+}
+
+func (p *obfsLocalPlugin) Close() error {
+	return nil
+}

--- a/Other/v2ray-sn/quic-conn.patch
+++ b/Other/v2ray-sn/quic-conn.patch
@@ -1,0 +1,95 @@
+diff --git a/app/dns/nameserver_quic.go b/app/dns/nameserver_quic.go
+index 14f2d0fd..75904335 100644
+--- a/app/dns/nameserver_quic.go
++++ b/app/dns/nameserver_quic.go
+@@ -37,7 +37,7 @@ type QUICNameServer struct {
+ 	reqID         uint32
+ 	name          string
+ 	destination   net.Destination
+-	session       quic.Session
++	session       quic.Connection
+ 	disableExpire bool
+ }
+ 
+@@ -323,7 +323,7 @@ func (s *QUICNameServer) QueryIP(ctx context.Context, domain string, clientIP ne
+ 	}
+ }
+ 
+-func isActive(s quic.Session) bool {
++func isActive(s quic.Connection) bool {
+ 	select {
+ 	case <-s.Context().Done():
+ 		return false
+@@ -332,8 +332,8 @@ func isActive(s quic.Session) bool {
+ 	}
+ }
+ 
+-func (s *QUICNameServer) getSession(ctx context.Context) (quic.Session, error) {
+-	var session quic.Session
++func (s *QUICNameServer) getSession(ctx context.Context) (quic.Connection, error) {
++	var session quic.Connection
+ 	s.RLock()
+ 	session = s.session
+ 	if session != nil && isActive(session) {
+@@ -366,7 +366,7 @@ func (s *QUICNameServer) getSession(ctx context.Context) (quic.Session, error) {
+ 	return session, nil
+ }
+ 
+-func (s *QUICNameServer) openSession(ctx context.Context) (quic.Session, error) {
++func (s *QUICNameServer) openSession(ctx context.Context) (quic.Connection, error) {
+ 	tlsConfig := tls.Config{}
+ 	quicConfig := &quic.Config{
+ 		HandshakeIdleTimeout: handshakeIdleTimeout,
+diff --git a/transport/internet/quic/dialer.go b/transport/internet/quic/dialer.go
+index c2d90d67..9d7ca2a1 100644
+--- a/transport/internet/quic/dialer.go
++++ b/transport/internet/quic/dialer.go
+@@ -16,7 +16,7 @@ import (
+ 
+ type sessionContext struct {
+ 	rawConn *sysConn
+-	session quic.Session
++	session quic.Connection
+ }
+ 
+ var errSessionClosed = newError("session closed")
+@@ -46,7 +46,7 @@ type clientSessions struct {
+ 	cleanup  *task.Periodic
+ }
+ 
+-func isActive(s quic.Session) bool {
++func isActive(s quic.Connection) bool {
+ 	select {
+ 	case <-s.Context().Done():
+ 		return false
+@@ -151,7 +151,7 @@ func (s *clientSessions) openConnection(destAddr net.Addr, config *Config, tlsCo
+ 		ConnectionIDLength:   12,
+ 		HandshakeIdleTimeout: time.Second * 8,
+ 		MaxIdleTimeout:       time.Second * 30,
+-		KeepAlive:            true,
++		KeepAlivePeriod:      time.Second * 15,
+ 	}
+ 
+ 	conn, err := wrapSysConn(rawConn.(*net.UDPConn), config)
+diff --git a/transport/internet/quic/hub.go b/transport/internet/quic/hub.go
+index a771cdb2..84e926d2 100644
+--- a/transport/internet/quic/hub.go
++++ b/transport/internet/quic/hub.go
+@@ -22,7 +22,7 @@ type Listener struct {
+ 	addConn  internet.ConnHandler
+ }
+ 
+-func (l *Listener) acceptStreams(session quic.Session) {
++func (l *Listener) acceptStreams(session quic.Connection) {
+ 	for {
+ 		stream, err := session.AcceptStream(context.Background())
+ 		if err != nil {
+@@ -107,7 +107,7 @@ func Listen(ctx context.Context, address net.Address, port net.Port, streamSetti
+ 		MaxIdleTimeout:        time.Second * 45,
+ 		MaxIncomingStreams:    32,
+ 		MaxIncomingUniStreams: -1,
+-		KeepAlive:             true,
++		KeepAlivePeriod:       time.Second * 15,
+ 	}
+ 
+ 	conn, err := wrapSysConn(rawConn.(*net.UDPConn), config)

--- a/Other/v2ray-sn/ssr.go
+++ b/Other/v2ray-sn/ssr.go
@@ -1,0 +1,119 @@
+package self
+
+// Modified from: https://github.com/SagerNet/LibSagerNetCore/blob/main/ssr.go
+// License: GPLv3
+
+import (
+	"bytes"
+	"flag"
+	"strconv"
+
+	"github.com/Dreamacro/clash/transport/ssr/obfs"
+	"github.com/Dreamacro/clash/transport/ssr/protocol"
+	"github.com/v2fly/v2ray-core/v5/common/buf"
+	"github.com/v2fly/v2ray-core/v5/proxy/shadowsocks"
+	"github.com/v2fly/v2ray-core/v5/transport/internet"
+)
+
+var (
+	_ shadowsocks.SIP003Plugin   = (*shadowsocksrPlugin)(nil)
+	_ shadowsocks.StreamPlugin   = (*shadowsocksrPlugin)(nil)
+	_ shadowsocks.ProtocolPlugin = (*shadowsocksrPlugin)(nil)
+)
+
+func init() {
+	shadowsocks.RegisterPlugin("shadowsocksr", func() shadowsocks.SIP003Plugin {
+		return new(shadowsocksrPlugin)
+	})
+}
+
+type shadowsocksrPlugin struct {
+	host          string
+	port          int
+	obfs          string
+	obfsParam     string
+	protocol      string
+	protocolParam string
+
+	o obfs.Obfs
+	p protocol.Protocol
+}
+
+func (p *shadowsocksrPlugin) Init(_ string, _ string, remoteHost string, remotePort string, _ string, pluginArgs []string, account *shadowsocks.MemoryAccount) error {
+	fs := flag.NewFlagSet("shadowsocksr", flag.ContinueOnError)
+	fs.StringVar(&p.obfs, "obfs", "origin", "")
+	fs.StringVar(&p.obfsParam, "obfs-param", "", "")
+	fs.StringVar(&p.protocol, "protocol", "origin", "")
+	fs.StringVar(&p.protocolParam, "protocol-param", "", "")
+	if err := fs.Parse(pluginArgs); err != nil {
+		return newError("shadowsocksr: failed to parse args").Base(err)
+	}
+	p.host = remoteHost
+	p.port, _ = strconv.Atoi(remotePort)
+
+	obfs, obfsOverhead, err := obfs.PickObfs(p.obfs, &obfs.Base{
+		Host:   p.host,
+		Port:   p.port,
+		Key:    account.Key,
+		IVSize: int(account.Cipher.IVSize()),
+		Param:  p.obfsParam,
+	})
+	if err != nil {
+		return newError("failed to create ssr obfs").Base(err)
+	}
+
+	protocol, err := protocol.PickProtocol(p.protocol, &protocol.Base{
+		Key:      account.Key,
+		Overhead: obfsOverhead,
+		Param:    p.protocolParam,
+	})
+	if err != nil {
+		return newError("failed to create ssr protocol").Base(err)
+	}
+
+	p.o = obfs
+	p.p = protocol
+
+	return nil
+}
+
+func (p *shadowsocksrPlugin) Close() error {
+	return nil
+}
+
+func (p *shadowsocksrPlugin) StreamConn(conn internet.Connection) internet.Connection {
+	return p.o.StreamConn(conn)
+}
+
+func (p *shadowsocksrPlugin) ProtocolConn(conn *shadowsocks.ProtocolConn, iv []byte) {
+	upstream := buf.NewConnection(buf.ConnectionOutputMulti(conn), buf.ConnectionInputMulti(conn))
+	downstream := p.p.StreamConn(upstream, iv)
+	if upstream == downstream {
+		conn.ProtocolReader = conn
+		conn.ProtocolWriter = conn
+	} else {
+		conn.ProtocolReader = buf.NewReader(downstream)
+		conn.ProtocolWriter = buf.NewWriter(downstream)
+	}
+}
+
+func (p *shadowsocksrPlugin) EncodePacket(buffer *buf.Buffer) (*buf.Buffer, error) {
+	defer buffer.Release()
+	packet := &bytes.Buffer{}
+	if err := p.p.EncodePacket(packet, buffer.Bytes()); err != nil {
+		return nil, err
+	}
+	return buf.FromBytes(packet.Bytes()), nil
+}
+
+func (p *shadowsocksrPlugin) DecodePacket(buffer *buf.Buffer) (*buf.Buffer, error) {
+	defer buffer.Release()
+	packet, err := p.p.DecodePacket(buffer.Bytes())
+	if err != nil {
+		return nil, err
+	}
+	newBuffer := buf.New()
+	newBuffer.Write(packet)
+	newBuffer.Endpoint = buffer.Endpoint
+	return newBuffer, nil
+}


### PR DESCRIPTION
## Summary
- bundle SSR and obfs plugins locally and copy them into v2ray core
- pin v2ray-sn to quic-go v0.31.0 and run `go mod tidy` before build

## Testing
- `pwsh Other/v2ray-sn/build.ps1` *(fails: command not found: pwsh)*
- `apt-get update >/tmp/apt.log && apt-get install -y powershell >>/tmp/apt.log && tail -n 20 /tmp/apt.log` *(fails: Invalid response from proxy: HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b558b104a483229b8027b6fe91dfcb