### PR TITLE
Refine TUN shutdown sequencing

### DIFF
--- a/Netch/Controllers/TUNController.cs
+++ b/Netch/Controllers/TUNController.cs
@@ -119,9 +119,11 @@ namespace Netch.Controllers
 
         public async Task StopAsync()
         {
+            if (!await FreeAsync().ConfigureAwait(false))
+                throw new MessageException("tun2socks free failed.");
+
             var tasks = new[]
             {
-                FreeAsync(),
                 Task.Run(ClearRouteTable),
                 _aioDnsController.StopAsync()
             };

--- a/Netch/Interops/tun2socks.cs
+++ b/Netch/Interops/tun2socks.cs
@@ -49,31 +49,9 @@ namespace Netch.Interops
             return tun_init();
         }
 
-        public static async Task<bool> FreeAsync()
+        public static Task<bool> FreeAsync(CancellationToken cancellationToken = default)
         {
-            var tcs = new TaskCompletionSource<bool>();
-            new Thread(() =>
-            {
-                try
-                {
-                    tcs.TrySetResult(tun_free());
-                }
-                catch (Exception e)
-                {
-                    tcs.TrySetException(e);
-                }
-            })
-            {
-                IsBackground = true
-            }.Start();
-
-            var completed = await Task.WhenAny(tcs.Task, Task.Delay(TimeSpan.FromSeconds(5))).ConfigureAwait(false);
-            if (completed != tcs.Task)
-            {
-                Log.Warning("[tun2socks] free timed out");
-                return false;
-            }
-            return await tcs.Task.ConfigureAwait(false);
+            return Task.Run(() => tun_free(), cancellationToken);
         }
 
         private const string tun2socks_bin = "tun2socks.bin";


### PR DESCRIPTION
## Summary
- remove timeout in tun2socks FreeAsync and allow optional cancellation
- ensure TUNController stops tun2socks before clearing routes or DNS

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ff5d39748322b0c6273177202bb4