### PR TITLE
Stabilize TUN teardown on Windows 11 24H2

### DIFF
--- a/Netch/Utils/NetworkInterfaceUtils.cs
+++ b/Netch/Utils/NetworkInterfaceUtils.cs
@@ -1,8 +1,10 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Management;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
+using System.Threading;
+using Serilog;
 using Windows.Win32;
 using Netch.Models;
 
@@ -12,17 +14,12 @@ public static class NetworkInterfaceUtils
 {
     public static NetworkInterface GetBest(AddressFamily addressFamily = AddressFamily.InterNetwork)
     {
-        string ipAddress;
-        switch (addressFamily)
+        string ipAddress = addressFamily switch
         {
-            case AddressFamily.InterNetwork:
-                ipAddress = "114.114.114.114";
-                break;
-            case AddressFamily.InterNetworkV6:
-                throw new NotImplementedException();
-            default:
-                throw new InvalidOperationException();
-        }
+            AddressFamily.InterNetwork => "114.114.114.114",
+            AddressFamily.InterNetworkV6 => throw new NotImplementedException(),
+            _ => throw new InvalidOperationException()
+        };
 
         if (PInvoke.GetBestRoute(BitConverter.ToUInt32(IPAddress.Parse(ipAddress).GetAddressBytes(), 0), 0, out var route) != 0)
             throw new MessageException("GetBestRoute 搜索失败");
@@ -51,6 +48,111 @@ public static class NetworkInterfaceUtils
             UseShellExecute = false,
             Verb = "runas"
         })!.WaitForExit();
+    }
+
+    public static bool TrySetInterfaceAdminStatus(int interfaceIndex, bool enable, TimeSpan? waitTimeout = null,
+        TimeSpan? commandTimeout = null)
+    {
+        string? adapterName = NetworkInterface.GetAllNetworkInterfaces()
+            .FirstOrDefault(ni => ni.GetIndex() == interfaceIndex)?.Name;
+
+        if (adapterName == null)
+        {
+            Log.Warning("Interface {InterfaceIndex} not found while toggling admin state", interfaceIndex);
+            return false;
+        }
+
+        var arguments =
+            $"interface set interface name=\"{adapterName}\" admin={(enable ? "ENABLED" : "DISABLED")}";
+        var timeout = (int)(commandTimeout ?? TimeSpan.FromSeconds(5)).TotalMilliseconds;
+
+        try
+        {
+            using var process = new Process
+            {
+                StartInfo = new ProcessStartInfo("netsh.exe", arguments)
+                {
+                    UseShellExecute = false,
+                    RedirectStandardError = true,
+                    RedirectStandardOutput = true,
+                    CreateNoWindow = true,
+                    Verb = "runas"
+                }
+            };
+
+            if (!process.Start())
+            {
+                Log.Warning("Failed to launch netsh when toggling interface {InterfaceIndex}", interfaceIndex);
+                return false;
+            }
+
+            if (!process.WaitForExit(timeout))
+            {
+                try
+                {
+                    process.Kill(true);
+                }
+                catch
+                {
+                    // ignored
+                }
+
+                Log.Warning("netsh timed out while changing admin state of interface {InterfaceIndex}", interfaceIndex);
+                return false;
+            }
+
+            if (process.ExitCode != 0)
+            {
+                var output = process.StandardOutput.ReadToEnd();
+                var error = process.StandardError.ReadToEnd();
+                Log.Warning(
+                    "netsh failed to change admin state of interface {InterfaceIndex}. Exit {ExitCode}. Output: {Output}. Error: {Error}",
+                    interfaceIndex, process.ExitCode, output, error);
+                return false;
+            }
+        }
+        catch (Exception e)
+        {
+            Log.Warning(e, "Exception while changing admin state of interface {InterfaceIndex}", interfaceIndex);
+            return false;
+        }
+
+        if (waitTimeout.HasValue)
+        {
+            var targetStatus = enable ? OperationalStatus.Up : OperationalStatus.Down;
+            var treatMissingAsMatch = !enable;
+
+            if (!WaitForOperationalStatus(interfaceIndex, targetStatus, waitTimeout.Value, treatMissingAsMatch))
+                Log.Warning("Timed out waiting for interface {InterfaceIndex} to reach {Status}", interfaceIndex, targetStatus);
+        }
+
+        return true;
+    }
+
+    public static bool WaitForOperationalStatus(int interfaceIndex, OperationalStatus status, TimeSpan timeout,
+        bool treatMissingAsMatch = false)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            var adapter = NetworkInterface.GetAllNetworkInterfaces()
+                .FirstOrDefault(ni => ni.GetIndex() == interfaceIndex);
+
+            if (adapter == null)
+            {
+                if (treatMissingAsMatch)
+                    return true;
+            }
+            else if (adapter.OperationalStatus == status)
+            {
+                return true;
+            }
+
+            Thread.Sleep(TimeSpan.FromMilliseconds(200));
+        }
+
+        return false;
     }
 }
 


### PR DESCRIPTION
## Summary
- add timeout-based tun shutdown with a Windows 11 24H2 fallback that temporarily disables the adapter via netsh and restores it once tun2socks exits
- provide NetworkInterfaceUtils helpers to toggle adapter admin state with netsh and wait on OperationalStatus so the Start button becomes usable again after stopping

## Testing
- `dotnet build Netch.sln` *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e8c2a38483229774fed701246782