### PR TITLE
Add VLESS Reality support

### DIFF
--- a/Netch/Controllers/MainController.cs
+++ b/Netch/Controllers/MainController.cs
@@ -61,7 +61,7 @@ public static class MainController
                 // Start Server Controller to get a local socks5 server
                 Log.Debug("Server Information: {Data}", $"{server.Type} {server.MaskedData()}");
 
-                ServerController = new V2rayController();
+                ServerController = CreateServerController(server);
                 Global.MainForm.StatusText(i18N.TranslateFormat("Starting {0}", ServerController.Name));
 
                 if (OperatingSystem.IsWindowsVersionAtLeast(8, 1))
@@ -95,6 +95,11 @@ public static class MainController
                     throw new MessageException($"{i18N.Translate("Unhandled Exception")}\n{e.Message}");
             }
         }
+    }
+
+    private static IServerController CreateServerController(Server server)
+    {
+        return server is VLESSServer { TLSSecureType: "reality" } ? new XrayController() : new V2rayController();
     }
 
     public static async Task StopAsync()

--- a/Netch/Servers/V2ray/V2rayConfig.cs
+++ b/Netch/Servers/V2ray/V2rayConfig.cs
@@ -110,6 +110,8 @@ public class StreamSettings
 
     public TlsSettings tlsSettings { get; set; }
 
+    public RealitySettings realitySettings { get; set; }
+
     public TcpSettings tcpSettings { get; set; }
 
     public KcpSettings kcpSettings { get; set; }
@@ -134,6 +136,19 @@ public class TlsSettings
     public bool allowInsecure { get; set; }
 
     public string serverName { get; set; }
+}
+
+public class RealitySettings
+{
+    public string fingerprint { get; set; }
+
+    public string serverName { get; set; }
+
+    public string publicKey { get; set; }
+
+    public string shortId { get; set; }
+
+    public string spiderX { get; set; }
 }
 
 public class TcpSettings

--- a/Netch/Servers/V2ray/V2rayConfigUtils.cs
+++ b/Netch/Servers/V2ray/V2rayConfigUtils.cs
@@ -84,7 +84,7 @@ public static class V2rayConfigUtils
                             new User
                             {
                                 id = getUUID(vless.UserID),
-                                flow = vless.TLSSecureType == "xtls" ? "xtls-rprx-direct" : "",
+                                flow = getVlessFlow(vless),
                                 encryption = vless.EncryptMethod
                             }
                         }
@@ -96,7 +96,7 @@ public static class V2rayConfigUtils
 
                 outbound.streamSettings = boundStreamSettings(vless);
 
-                if (vless.TLSSecureType == "xtls")
+                if (vless.TLSSecureType is "xtls" or "reality")
                 {
                     outbound.mux.enabled = false;
                     outbound.mux.concurrency = -1;
@@ -320,6 +320,19 @@ public static class V2rayConfigUtils
                 case "xtls":
                     streamSettings.xtlsSettings = tlsSettings;
                     break;
+                case "reality":
+                    if (server is not VLESSServer vless)
+                        throw new MessageException("Reality is only supported by VLESS");
+
+                    streamSettings.realitySettings = new RealitySettings
+                    {
+                        fingerprint = vless.Fingerprint.ValueOrDefault(),
+                        serverName = vless.ServerName.ValueOrDefault() ?? vless.Host.SplitOrDefault()?[0],
+                        publicKey = vless.PublicKey.ValueOrDefault(),
+                        shortId = vless.ShortId.ValueOrDefault(),
+                        spiderX = vless.SpiderX.ValueOrDefault()
+                    };
+                    break;
             }
         }
 
@@ -433,5 +446,13 @@ public static class V2rayConfigUtils
             return uuid;
         }
         return uuid.GenerateUUIDv5();
+    }
+
+    private static string getVlessFlow(VLESSServer server)
+    {
+        if (!server.Flow.IsNullOrWhiteSpace())
+            return server.Flow!;
+
+        return server.TLSSecureType == "xtls" ? "xtls-rprx-direct" : "";
     }
 }

--- a/Netch/Servers/V2ray/V2rayController.cs
+++ b/Netch/Servers/V2ray/V2rayController.cs
@@ -8,10 +8,14 @@ namespace Netch.Servers;
 
 public class V2rayController : Guard, IServerController
 {
-    public V2rayController() : base("v2ray-sn.exe")
+    protected V2rayController(string executableName) : base(executableName)
     {
         //if (!Global.Settings.V2RayConfig.XrayCone)
         //    Instance.StartInfo.Environment["XRAY_CONE_DISABLED"] = "true";
+    }
+
+    public V2rayController() : this("v2ray-sn.exe")
+    {
     }
 
     protected override IEnumerable<string> StartedKeywords => new[] { "started" };
@@ -34,4 +38,13 @@ public class V2rayController : Guard, IServerController
         await StartGuardAsync("run -c ..\\data\\last.json");
         return new Socks5Server(IPAddress.Loopback.ToString(), this.Socks5LocalPort(), s.Hostname);
     }
+}
+
+public class XrayController : V2rayController
+{
+    public XrayController() : base("xray.exe")
+    {
+    }
+
+    public override string Name => "Xray";
 }

--- a/Netch/Servers/V2ray/V2rayUtils.cs
+++ b/Netch/Servers/V2ray/V2rayUtils.cs
@@ -56,6 +56,15 @@ public static class V2rayUtils
             {
                 server.ServerName = parameter.Get("sni") ?? "";
             }
+
+            if (server is VLESSServer vless)
+            {
+                vless.Flow = parameter.Get("flow") ?? "";
+                vless.Fingerprint = parameter.Get("fp") ?? "";
+                vless.PublicKey = parameter.Get("pbk") ?? "";
+                vless.ShortId = parameter.Get("sid") ?? "";
+                vless.SpiderX = Uri.UnescapeDataString(parameter.Get("spx") ?? "");
+            }
         }
 
         var finder = new Regex(@$"^{scheme}://(?<guid>.+?)@(?<server>.+):(?<port>\d+)");
@@ -130,12 +139,31 @@ public static class V2rayUtils
         {
             parameter.Add("security", server.TLSSecureType);
 
-            if (!server.Host.IsNullOrWhiteSpace())
-                parameter.Add("sni", server.Host!);
+            var sni = server.ServerName.ValueOrDefault() ?? server.Host.ValueOrDefault();
+            if (!sni.IsNullOrWhiteSpace())
+                parameter.Add("sni", Uri.EscapeDataString(sni!));
 
             if (server.TLSSecureType == "xtls")
             {
-                parameter.Add("flow", "xtls-rprx-direct");
+                parameter.Add("flow", server is VLESSServer { Flow: { } flow } && !flow.IsNullOrWhiteSpace() ? flow : "xtls-rprx-direct");
+            }
+
+            if (server is VLESSServer vless && server.TLSSecureType == "reality")
+            {
+                if (!vless.Flow.IsNullOrWhiteSpace())
+                    parameter.Add("flow", vless.Flow!);
+
+                if (!vless.Fingerprint.IsNullOrWhiteSpace())
+                    parameter.Add("fp", vless.Fingerprint!);
+
+                if (!vless.PublicKey.IsNullOrWhiteSpace())
+                    parameter.Add("pbk", vless.PublicKey!);
+
+                if (!vless.ShortId.IsNullOrWhiteSpace())
+                    parameter.Add("sid", vless.ShortId!);
+
+                if (!vless.SpiderX.IsNullOrWhiteSpace())
+                    parameter.Add("spx", Uri.EscapeDataString(vless.SpiderX!));
             }
         }
 

--- a/Netch/Servers/VLESS/VLESSForm.cs
+++ b/Netch/Servers/VLESS/VLESSForm.cs
@@ -33,6 +33,11 @@ internal class VLESSForm : ServerForm
         CreateTextBox("Path", "Path", s => true, s => server.Path = s, server.Path);
         CreateComboBox("QUICSecurity", "QUIC Security", VLESSGlobal.QUIC, s => server.QUICSecure = s, server.QUICSecure);
         CreateTextBox("QUICSecret", "QUIC Secret", s => true, s => server.QUICSecret = s, server.QUICSecret);
+        CreateComboBox("Flow", "Flow", VLESSGlobal.Flows, s => server.Flow = s, server.Flow);
+        CreateComboBox("Fingerprint", "Fingerprint", VLESSGlobal.Fingerprints, s => server.Fingerprint = s, server.Fingerprint);
+        CreateTextBox("PublicKey", "Reality Public Key", s => true, s => server.PublicKey = s, server.PublicKey);
+        CreateTextBox("ShortId", "Reality Short ID", s => true, s => server.ShortId = s, server.ShortId);
+        CreateTextBox("SpiderX", "Reality SpiderX", s => true, s => server.SpiderX = s, server.SpiderX);
         CreateComboBox("UseMux",
             "Use Mux",
             new List<string> { "", "true", "false" },

--- a/Netch/Servers/VLESS/VLESSServer.cs
+++ b/Netch/Servers/VLESS/VLESSServer.cs
@@ -18,6 +18,31 @@ public class VLESSServer : VMessServer
     ///     伪装类型
     /// </summary>
     public override string FakeType { get; set; } = VLESSGlobal.FakeTypes[0];
+
+    /// <summary>
+    ///     VLESS flow，例如 xtls-rprx-vision
+    /// </summary>
+    public string? Flow { get; set; } = string.Empty;
+
+    /// <summary>
+    ///     Reality uTLS 指纹
+    /// </summary>
+    public string? Fingerprint { get; set; } = string.Empty;
+
+    /// <summary>
+    ///     Reality public key
+    /// </summary>
+    public string? PublicKey { get; set; } = string.Empty;
+
+    /// <summary>
+    ///     Reality short id
+    /// </summary>
+    public string? ShortId { get; set; } = string.Empty;
+
+    /// <summary>
+    ///     Reality spiderX
+    /// </summary>
+    public string? SpiderX { get; set; } = string.Empty;
 }
 
 public class VLESSGlobal
@@ -26,7 +51,30 @@ public class VLESSGlobal
     {
         "none",
         "tls",
-        "xtls"
+        "xtls",
+        "reality"
+    };
+
+    public static readonly List<string> Flows = new()
+    {
+        "",
+        "xtls-rprx-vision",
+        "xtls-rprx-direct"
+    };
+
+    public static readonly List<string> Fingerprints = new()
+    {
+        "",
+        "chrome",
+        "firefox",
+        "safari",
+        "ios",
+        "android",
+        "edge",
+        "360",
+        "qq",
+        "random",
+        "randomized"
     };
 
     public static List<string> FakeTypes => VMessGlobal.FakeTypes;

--- a/Other/xray-core/build.ps1
+++ b/Other/xray-core/build.ps1
@@ -1,0 +1,14 @@
+Set-Location (Split-Path $MyInvocation.MyCommand.Path -Parent)
+
+$release = Invoke-RestMethod -Uri 'https://api.github.com/repos/XTLS/Xray-core/releases/latest'
+$asset = $release.assets | Where-Object { $_.name -eq 'Xray-windows-64.zip' } | Select-Object -First 1
+if ( $null -eq $asset ) {
+    Write-Host 'Xray windows amd64 release asset not found'
+    exit 1
+}
+
+Invoke-WebRequest -Uri $asset.browser_download_url -OutFile 'xray.zip'
+Expand-Archive -Force -Path 'xray.zip' -DestinationPath 'xray'
+mv -Force 'xray\xray.exe' '..\release\xray.exe'
+
+exit $lastExitCode


### PR DESCRIPTION
### Motivation
- 为了支持 VLESS 的 Reality 传输（uTLS/fingerprint、public key、short id、spiderX），需要在服务端模型、配置生成、URI 解析/导出、UI 和运行时代理内核间做最小侵入式扩展以保持向后兼容。 

### Description
- 在 `VLESSServer` 中新增 Reality 相关字段：`Flow`, `Fingerprint`, `PublicKey`, `ShortId`, `SpiderX`，并将 `reality` 加入 TLS 类型列表；同时新增 `VLESSGlobal.Flows` 与 `VLESSGlobal.Fingerprints` 用于 UI 下拉。 
- 在 VLESS 编辑窗体 `VLESSForm` 添加对应输入控件，支持用户在 GUI 中填写 Reality 参数。 
- 扩展 V2Ray 配置模型 `StreamSettings`，新增 `RealitySettings` 并在 `V2rayConfigUtils` 中生成 `realitySettings`（包含 fingerprint、serverName、publicKey、shortId、spiderX）；对 Reality/XTLS 自动禁用 mux，以保证兼容性。 
- 在 `V2rayUtils` 中扩展 URI 解析与分享链接导出，支持解析/导出参数 `flow`、`fp`、`pbk`、`sid`、`spx`，并改进 `sni` 优先取 `ServerName`（SNI）再回退到 `Host`。 
- 增加 `XrayController`（继承 `V2rayController`），并在启动时根据服务器 `TLSSecureType == "reality"` 选择 `xray.exe`（Reality）或 `v2ray-sn.exe`（非 Reality），保留原有行为以避免破坏兼容性。 
- 新增构建脚本 `Other/xray-core/build.ps1` 用于在 release 流程中获取 Xray Windows 可执行文件。 

### Testing
- 运行 `git diff --check`，未发现问题（成功）。
- 试图运行 `dotnet build Netch/Netch.csproj -p:Platform=x64 --no-restore` 进行编译验证，但容器中未安装 `dotnet`，构建未执行（环境限制）。
- 试图运行 PowerShell (`pwsh`) 检查环境，但容器中未安装 `pwsh`，检查未执行（环境限制）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1af32f010c832295018b312457a629)