### PR TITLE
CI: 显式安装 .NET 6 并在 Other 缓存检查中包含 xray.exe

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '6.0.x'
+
       - name: Checksum
         shell: pwsh
         run: |
@@ -49,7 +54,7 @@ jobs:
         id: check_other
         uses: andstor/file-existence-action@v2
         with:
-          files: .\other\release\aiodns.bin
+          files: .\Other\release\aiodns.bin, .\Other\release\xray.exe
 
       - name: Setup Go
         uses: actions/setup-go@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '6.0.x'
+
       - name: Checksum
         shell: pwsh
         run: |
@@ -45,7 +50,7 @@ jobs:
         id: check_other
         uses: andstor/file-existence-action@v2
         with:
-          files: .\other\release\aiodns.bin
+          files: .\Other\release\aiodns.bin, .\Other\release\xray.exe
 
       - name: Setup Go
         uses: actions/setup-go@v3


### PR DESCRIPTION
### Motivation
- 修复 GitHub Actions 在 `windows-2022` runner 上可能没有合适 .NET SDK 导致的编译失败，并确保新增 Reality 支持不会因为 `Other` 缓存缺少 `xray.exe` 而生成不完整的产物。

### Description
- 在 ` .github/workflows/build.yml` 和 ` .github/workflows/release.yml` 中加入 `actions/setup-dotnet@v4` (`dotnet-version: '6.0.x'`)，并将 `Check Other` 的文件列表从 `./Other/release/aiodns.bin` 扩展为 `./Other/release/aiodns.bin, ./Other/release/xray.exe`。

### Testing
- 使用 `ruby -e "require 'yaml'..."` 校验两个 workflow 文件的 YAML 解析并使用 `git diff --check` 检查代码风格，均通过。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b0199cf0c83228ba9eaa437f7d9b6)