### PR TITLE
Add VLESS Reality transport support and Xray runtime integration

### DIFF
--- a/Netch/Controllers/MainController.cs
+++ b/Netch/Controllers/MainController.cs
@@ -61,7 +61,7 @@ public static class MainController
                 // Start Server Controller to get a local socks5 server
                 Log.Debug("Server Information: {Data}", $"{server.Type} {server.MaskedData()}");
 
-                ServerController = new V2rayController();
+                ServerController = CreateServerController(server);
                 Global.MainForm.StatusText(i18N.TranslateFormat("Starting {0}", ServerController.Name));
 
                 if (OperatingSystem.IsWindowsVersionAtLeast(8, 1))
@@ -95,6 +95,11 @@ public static class MainController
                     throw new MessageException($"{i18N.Translate("Unhandled Exception")}\n{e.Message}");
             }
         }
+    }
+
+    private static IServerController CreateServerController(Server server)
+    {
+        return server is VLESSServer { TLSSecureType: "reality" } ? new XrayController() : new V2rayController();
     }
 
     public static async Task StopAsync()

--- a/Netch/Servers/V2ray/V2rayConfig.cs
+++ b/Netch/Servers/V2ray/V2rayConfig.cs
@@ -110,6 +110,8 @@ public class StreamSettings
 
     public TlsSettings tlsSettings { get; set; }
 
+    public RealitySettings realitySettings { get; set; }
+
     public TcpSettings tcpSettings { get; set; }
 
     public KcpSettings kcpSettings { get; set; }
@@ -134,6 +136,19 @@ public class TlsSettings
     public bool allowInsecure { get; set; }
 
     public string serverName { get; set; }
+}
+
+public class RealitySettings
+{
+    public string fingerprint { get; set; }
+
+    public string serverName { get; set; }
+
+    public string publicKey { get; set; }
+
+    public string shortId { get; set; }
+
+    public string spiderX { get; set; }
 }
 
 public class TcpSettings

--- a/Netch/Servers/V2ray/V2rayConfigUtils.cs
+++ b/Netch/Servers/V2ray/V2rayConfigUtils.cs
@@ -22,7 +22,8 @@ public static class V2rayConfigUtils
                     {
                         auth = "noauth",
                         udp = true
-                    }
+                    },
+                    sniffing = inboundSniffing(server)
                 }
             }
         };
@@ -30,6 +31,20 @@ public static class V2rayConfigUtils
         v2rayConfig.outbounds = new[] { await outbound(server) };
 
         return v2rayConfig;
+    }
+
+    private static object? inboundSniffing(Server server)
+    {
+        if (server is not VLESSServer { TLSSecureType: "reality" })
+            return null;
+
+        return new
+        {
+            enabled = true,
+            destOverride = new[] { "http", "tls", "quic" },
+            metadataOnly = false,
+            routeOnly = false
+        };
     }
 
     private static async Task<Outbound> outbound(Server server)
@@ -84,7 +99,7 @@ public static class V2rayConfigUtils
                             new User
                             {
                                 id = getUUID(vless.UserID),
-                                flow = vless.TLSSecureType == "xtls" ? "xtls-rprx-direct" : "",
+                                flow = getVlessFlow(vless),
                                 encryption = vless.EncryptMethod
                             }
                         }
@@ -96,7 +111,7 @@ public static class V2rayConfigUtils
 
                 outbound.streamSettings = boundStreamSettings(vless);
 
-                if (vless.TLSSecureType == "xtls")
+                if (vless.TLSSecureType is "xtls" or "reality")
                 {
                     outbound.mux.enabled = false;
                     outbound.mux.concurrency = -1;
@@ -320,6 +335,19 @@ public static class V2rayConfigUtils
                 case "xtls":
                     streamSettings.xtlsSettings = tlsSettings;
                     break;
+                case "reality":
+                    if (server is not VLESSServer vless)
+                        throw new MessageException("Reality is only supported by VLESS");
+
+                    streamSettings.realitySettings = new RealitySettings
+                    {
+                        fingerprint = vless.Fingerprint.ValueOrDefault(),
+                        serverName = vless.ServerName.ValueOrDefault() ?? vless.Host.SplitOrDefault()?[0],
+                        publicKey = vless.PublicKey.ValueOrDefault(),
+                        shortId = vless.ShortId.ValueOrDefault(),
+                        spiderX = vless.SpiderX.ValueOrDefault()
+                    };
+                    break;
             }
         }
 
@@ -433,5 +461,13 @@ public static class V2rayConfigUtils
             return uuid;
         }
         return uuid.GenerateUUIDv5();
+    }
+
+    private static string getVlessFlow(VLESSServer server)
+    {
+        if (!server.Flow.IsNullOrWhiteSpace())
+            return server.Flow!;
+
+        return server.TLSSecureType == "xtls" ? "xtls-rprx-direct" : "";
     }
 }

--- a/Netch/Servers/V2ray/V2rayController.cs
+++ b/Netch/Servers/V2ray/V2rayController.cs
@@ -8,10 +8,14 @@ namespace Netch.Servers;
 
 public class V2rayController : Guard, IServerController
 {
-    public V2rayController() : base("v2ray-sn.exe")
+    protected V2rayController(string executableName) : base(executableName)
     {
         //if (!Global.Settings.V2RayConfig.XrayCone)
         //    Instance.StartInfo.Environment["XRAY_CONE_DISABLED"] = "true";
+    }
+
+    public V2rayController() : this("v2ray-sn.exe")
+    {
     }
 
     protected override IEnumerable<string> StartedKeywords => new[] { "started" };
@@ -34,4 +38,13 @@ public class V2rayController : Guard, IServerController
         await StartGuardAsync("run -c ..\\data\\last.json");
         return new Socks5Server(IPAddress.Loopback.ToString(), this.Socks5LocalPort(), s.Hostname);
     }
+}
+
+public class XrayController : V2rayController
+{
+    public XrayController() : base("xray.exe")
+    {
+    }
+
+    public override string Name => "Xray";
 }

--- a/Netch/Servers/V2ray/V2rayUtils.cs
+++ b/Netch/Servers/V2ray/V2rayUtils.cs
@@ -56,6 +56,15 @@ public static class V2rayUtils
             {
                 server.ServerName = parameter.Get("sni") ?? "";
             }
+
+            if (server is VLESSServer vless)
+            {
+                vless.Flow = parameter.Get("flow") ?? "";
+                vless.Fingerprint = parameter.Get("fp") ?? "";
+                vless.PublicKey = parameter.Get("pbk") ?? "";
+                vless.ShortId = parameter.Get("sid") ?? "";
+                vless.SpiderX = Uri.UnescapeDataString(parameter.Get("spx") ?? "");
+            }
         }
 
         var finder = new Regex(@$"^{scheme}://(?<guid>.+?)@(?<server>.+):(?<port>\d+)");
@@ -130,12 +139,31 @@ public static class V2rayUtils
         {
             parameter.Add("security", server.TLSSecureType);
 
-            if (!server.Host.IsNullOrWhiteSpace())
-                parameter.Add("sni", server.Host!);
+            var sni = server.ServerName.ValueOrDefault() ?? server.Host.ValueOrDefault();
+            if (!sni.IsNullOrWhiteSpace())
+                parameter.Add("sni", Uri.EscapeDataString(sni!));
 
             if (server.TLSSecureType == "xtls")
             {
-                parameter.Add("flow", "xtls-rprx-direct");
+                parameter.Add("flow", server is VLESSServer { Flow: { } flow } && !flow.IsNullOrWhiteSpace() ? flow : "xtls-rprx-direct");
+            }
+
+            if (server is VLESSServer vless && server.TLSSecureType == "reality")
+            {
+                if (!vless.Flow.IsNullOrWhiteSpace())
+                    parameter.Add("flow", vless.Flow!);
+
+                if (!vless.Fingerprint.IsNullOrWhiteSpace())
+                    parameter.Add("fp", vless.Fingerprint!);
+
+                if (!vless.PublicKey.IsNullOrWhiteSpace())
+                    parameter.Add("pbk", vless.PublicKey!);
+
+                if (!vless.ShortId.IsNullOrWhiteSpace())
+                    parameter.Add("sid", vless.ShortId!);
+
+                if (!vless.SpiderX.IsNullOrWhiteSpace())
+                    parameter.Add("spx", Uri.EscapeDataString(vless.SpiderX!));
             }
         }
 

--- a/Netch/Servers/VLESS/VLESSForm.cs
+++ b/Netch/Servers/VLESS/VLESSForm.cs
@@ -33,6 +33,11 @@ internal class VLESSForm : ServerForm
         CreateTextBox("Path", "Path", s => true, s => server.Path = s, server.Path);
         CreateComboBox("QUICSecurity", "QUIC Security", VLESSGlobal.QUIC, s => server.QUICSecure = s, server.QUICSecure);
         CreateTextBox("QUICSecret", "QUIC Secret", s => true, s => server.QUICSecret = s, server.QUICSecret);
+        CreateComboBox("Flow", "Flow", VLESSGlobal.Flows, s => server.Flow = s, server.Flow);
+        CreateComboBox("Fingerprint", "Fingerprint", VLESSGlobal.Fingerprints, s => server.Fingerprint = s, server.Fingerprint);
+        CreateTextBox("PublicKey", "Reality Public Key", s => true, s => server.PublicKey = s, server.PublicKey);
+        CreateTextBox("ShortId", "Reality Short ID", s => true, s => server.ShortId = s, server.ShortId);
+        CreateTextBox("SpiderX", "Reality SpiderX", s => true, s => server.SpiderX = s, server.SpiderX);
         CreateComboBox("UseMux",
             "Use Mux",
             new List<string> { "", "true", "false" },

--- a/Netch/Servers/VLESS/VLESSServer.cs
+++ b/Netch/Servers/VLESS/VLESSServer.cs
@@ -18,6 +18,31 @@ public class VLESSServer : VMessServer
     ///     伪装类型
     /// </summary>
     public override string FakeType { get; set; } = VLESSGlobal.FakeTypes[0];
+
+    /// <summary>
+    ///     VLESS flow，例如 xtls-rprx-vision
+    /// </summary>
+    public string? Flow { get; set; } = string.Empty;
+
+    /// <summary>
+    ///     Reality uTLS 指纹
+    /// </summary>
+    public string? Fingerprint { get; set; } = string.Empty;
+
+    /// <summary>
+    ///     Reality public key
+    /// </summary>
+    public string? PublicKey { get; set; } = string.Empty;
+
+    /// <summary>
+    ///     Reality short id
+    /// </summary>
+    public string? ShortId { get; set; } = string.Empty;
+
+    /// <summary>
+    ///     Reality spiderX
+    /// </summary>
+    public string? SpiderX { get; set; } = string.Empty;
 }
 
 public class VLESSGlobal
@@ -26,7 +51,30 @@ public class VLESSGlobal
     {
         "none",
         "tls",
-        "xtls"
+        "xtls",
+        "reality"
+    };
+
+    public static readonly List<string> Flows = new()
+    {
+        "",
+        "xtls-rprx-vision",
+        "xtls-rprx-direct"
+    };
+
+    public static readonly List<string> Fingerprints = new()
+    {
+        "",
+        "chrome",
+        "firefox",
+        "safari",
+        "ios",
+        "android",
+        "edge",
+        "360",
+        "qq",
+        "random",
+        "randomized"
     };
 
     public static List<string> FakeTypes => VMessGlobal.FakeTypes;

--- a/Other/xray-core/build.ps1
+++ b/Other/xray-core/build.ps1
@@ -1,0 +1,14 @@
+Set-Location (Split-Path $MyInvocation.MyCommand.Path -Parent)
+
+$release = Invoke-RestMethod -Uri 'https://api.github.com/repos/XTLS/Xray-core/releases/latest'
+$asset = $release.assets | Where-Object { $_.name -eq 'Xray-windows-64.zip' } | Select-Object -First 1
+if ( $null -eq $asset ) {
+    Write-Host 'Xray windows amd64 release asset not found'
+    exit 1
+}
+
+Invoke-WebRequest -Uri $asset.browser_download_url -OutFile 'xray.zip'
+Expand-Archive -Force -Path 'xray.zip' -DestinationPath 'xray'
+mv -Force 'xray\xray.exe' '..\release\xray.exe'
+
+exit $lastExitCode


### PR DESCRIPTION
### Motivation
- Add support for VLESS "reality" transport so users can configure Reality-specific fields and generate the correct client config.
- Use Xray runtime when a VLESS server uses Reality because Xray provides the needed implementation differences.
- Expose Reality-related fields in the server UI and share link generation so configuration can be created/parsed end-to-end.

### Description
- Add `RealitySettings` to the V2Ray config model and include `realitySettings` in `StreamSettings`, and enable inbound `sniffing` for Reality-managed servers.
- Extend `V2rayConfigUtils` to emit Reality settings for `VLESS` servers, adjust mux/flow logic, and add `getVlessFlow` helper to determine VLESS `flow` value.
- Make `V2rayController` extensible and add `XrayController` (runs `xray.exe`) while updating `MainController` to instantiate `XrayController` when the server is a `VLESS` with `TLSSecureType == "reality"`.
- Extend `VLESSServer` data model and `VLESSForm` UI with properties `Flow`, `Fingerprint`, `PublicKey`, `ShortId`, and `SpiderX`, and add new option lists for `TLSSecure`/`Flows`/`Fingerprints`.
- Update `V2rayUtils` to parse Reality-specific query parameters (`flow`, `fp`, `pbk`, `sid`, `spx`) when reading URIs and to include them (plus proper SNI/spx escaping) when generating share links.
- Add `Other/xray-core/build.ps1` helper script to download the latest `xray.exe` release for packaging.

### Testing
- Built the solution with `dotnet build` successfully.
- Ran the automated test suite with `dotnet test` and all tests passed.
- Verified generation of client config for a VLESS Reality server via `V2rayConfigUtils.GenerateClientConfigAsync` in automated checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1af32f010c832295018b312457a629)