### PR TITLE
Fix native interop string termination, DNS error handling, and multiple utility bugs

### DIFF
--- a/Netch/Interops/AioDNS.cs
+++ b/Netch/Interops/AioDNS.cs
@@ -10,7 +10,14 @@ public static class AioDNS
     public static bool Dial(NameList name, string value)
     {
         Log.Verbose($"[aiodns] Dial {name}: {value}");
-        return aiodns_dial(name, Encoding.UTF8.GetBytes(value));
+        return aiodns_dial(name, NullTerminatedUtf8(value));
+    }
+
+    private static byte[] NullTerminatedUtf8(string value)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value);
+        Array.Resize(ref bytes, bytes.Length + 1);
+        return bytes;
     }
 
     public static Task<bool> InitAsync()

--- a/Netch/Interops/tun2socks.cs
+++ b/Netch/Interops/tun2socks.cs
@@ -40,7 +40,14 @@ namespace Netch.Interops
         public static bool Dial(NameList name, string value)
         {
             Log.Verbose( $"[tun2socks] Dial {name}: {value}");
-            return tun_dial(name, Encoding.UTF8.GetBytes(value));
+            return tun_dial(name, NullTerminatedUtf8(value));
+        }
+
+        private static byte[] NullTerminatedUtf8(string value)
+        {
+            var bytes = Encoding.UTF8.GetBytes(value);
+            Array.Resize(ref bytes, bytes.Length + 1);
+            return bytes;
         }
 
         public static bool Init()

--- a/Netch/Servers/V2ray/V2rayConfigUtils.cs
+++ b/Netch/Servers/V2ray/V2rayConfigUtils.cs
@@ -43,7 +43,7 @@ public static class V2rayConfigUtils
             enabled = true,
             destOverride = new[] { "tls", "quic" },
             metadataOnly = false,
-            routeOnly = true
+            routeOnly = false
         };
     }
 

--- a/Netch/Servers/V2ray/V2rayConfigUtils.cs
+++ b/Netch/Servers/V2ray/V2rayConfigUtils.cs
@@ -41,9 +41,9 @@ public static class V2rayConfigUtils
         return new
         {
             enabled = true,
-            destOverride = new[] { "http", "tls", "quic" },
+            destOverride = new[] { "tls", "quic" },
             metadataOnly = false,
-            routeOnly = false
+            routeOnly = true
         };
     }
 

--- a/Netch/Utils/ModeHelper.cs
+++ b/Netch/Utils/ModeHelper.cs
@@ -110,7 +110,7 @@ public static class ModeHelper
                     if (includeMode is TunMode tMode)
                     {
                         tunMode.Bypass.AddRange(tMode.Bypass);
-                        tMode.Handle.AddRange(tMode.Handle);
+                        tunMode.Handle.AddRange(tMode.Handle);
                         break;
                     }
 

--- a/Netch/Utils/NetworkInterfaceUtils.cs
+++ b/Netch/Utils/NetworkInterfaceUtils.cs
@@ -176,16 +176,18 @@ public static class NetworkInterfaceExtension
 
     public static void SetDns(this NetworkInterface ni, string primaryDns, string? secondDns = null)
     {
-        void VerifyDns(ref string s)
+        string VerifyDns(string s, string paramName)
         {
             s = s.Trim();
-            if (primaryDns.IsNullOrEmpty())
-                throw new ArgumentException("DNS format invalid", nameof(primaryDns));
+            if (s.IsNullOrEmpty())
+                throw new ArgumentException("DNS format invalid", paramName);
+
+            return s;
         }
 
-        VerifyDns(ref primaryDns);
+        primaryDns = VerifyDns(primaryDns, nameof(primaryDns));
         if (secondDns != null)
-            VerifyDns(ref primaryDns);
+            secondDns = VerifyDns(secondDns, nameof(secondDns));
 
         var wmi = new ManagementClass("Win32_NetworkAdapterConfiguration");
         var mos = wmi.GetInstances().Cast<ManagementObject>();

--- a/Netch/Utils/RouteUtils.cs
+++ b/Netch/Utils/RouteUtils.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using System.Net;
 using System.Net.Sockets;
 using Netch.Interops;
 using Netch.Models;
@@ -85,8 +86,13 @@ public static class RouteUtils
         if (s.Length != 2)
             return false;
 
-        ip = s[0];
-        cidr = int.Parse(s[1]);
+        if (!IPAddress.TryParse(s[0], out var address))
+            return false;
+
+        if (!int.TryParse(s[1], out cidr) || cidr is < 0 or > 32)
+            return false;
+
+        ip = address.ToString();
         return true;
     }
 }

--- a/Other/aiodns/main.go
+++ b/Other/aiodns/main.go
@@ -118,6 +118,8 @@ func aiodns_init() bool {
 	udpSocket, err = net.ListenPacket("udp", Listen)
 	if err != nil {
 		fmt.Printf("[aiodns][init] net.ListenPacket: %v\n", err)
+		tcpSocket.Close()
+		tcpSocket = nil
 		return false
 	}
 
@@ -164,6 +166,8 @@ func handleChinaDNS(w dns.ResponseWriter, m *dns.Msg) {
 	r, _, err := CDNS.Exchange(m, ChinaDNS)
 	if err != nil {
 		fmt.Printf("[aiodns] handleChinaDNS: %v\n", err)
+		r = new(dns.Msg)
+		r.SetRcode(m, dns.RcodeServerFailure)
 	}
 
 	_ = w.WriteMsg(r)
@@ -173,6 +177,8 @@ func handleOtherDNS(w dns.ResponseWriter, m *dns.Msg) {
 	r, _, err := ODNS.Exchange(m, OtherDNS)
 	if err != nil {
 		fmt.Printf("[aiodns] handleOtherDNS: %v\n", err)
+		r = new(dns.Msg)
+		r.SetRcode(m, dns.RcodeServerFailure)
 	}
 
 	_ = w.WriteMsg(r)


### PR DESCRIPTION
### Motivation
- Ensure native libraries receive null-terminated UTF-8 strings when invoked from managed code to avoid interop issues.
- Make `aiodns` server more robust by cleaning up sockets on partial failures and returning proper DNS error replies on upstream failures.
- Correct logic errors in mode merging and DNS/route utilities to prevent incorrect behavior or crashes.
- Harden input validation for DNS and IP network parsing to avoid invalid values being used.

### Description
- Added `NullTerminatedUtf8` helper and switched `Dial` calls in `AioDNS` and `tun2socks` to pass null-terminated UTF-8 byte arrays to native `*_dial` functions.
- Updated `Other/aiodns/main.go` to close the TCP listener if UDP listen fails and to respond with `SERVFAIL` when upstream DNS exchanges error.
- Adjusted V2Ray inbound sniffing for `reality` to remove `http` from `destOverride` and set `routeOnly = true` in `V2rayConfigUtils`.
- Fixed a bug in `ModeHelper` where `tunMode.Handle` was incorrectly updated, so included `TunMode` entries are merged into the current `tunMode` correctly.
- Improved DNS setter validation in `NetworkInterfaceExtension.SetDns` to validate each parameter and return the trimmed string, and corrected parameter names in exceptions.
- Strengthened `RouteUtils.TryParseIPNetwork` to validate the IP with `IPAddress.TryParse` and verify the CIDR is within `0..32` before returning the normalized IP string.

### Testing
- Built the .NET solution with `dotnet build` and the `aiodns` helper with `go build` for `Other/aiodns`; both builds completed successfully. 
- No automated tests were added or modified in this change. 
- Existing automated test suites were not altered by this PR. 
- Manual smoke checks were used to verify startup/cleanup behavior of `aiodns` and that native `*_dial` interop calls no longer pass unterminated byte arrays.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5cb1c4c814832287ac64725937eb63)