### PR TITLE
修复 CI 中 MSBuild 未找到的问题

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
           profile: minimal
 
       - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v1.3.1
+        uses: microsoft/setup-msbuild@v2
         with:
           vs-prerelease: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,11 @@ jobs:
           toolchain: nightly
           profile: minimal
 
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+        with:
+          vs-prerelease: true
+
       - name: Build
         shell: pwsh
         run: |

--- a/build.ps1
+++ b/build.ps1
@@ -24,6 +24,35 @@ param (
 
 Push-Location (Split-Path $MyInvocation.MyCommand.Path -Parent)
 
+function Invoke-MSBuild {
+	param (
+		[Parameter(Mandatory = $True)]
+		[string]
+		$Project
+	)
+
+	$MSBuild = Get-Command msbuild -ErrorAction SilentlyContinue
+	if ( -Not $MSBuild ) {
+		$VSWhere = "${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+		if ( Test-Path $VSWhere ) {
+			$MSBuildPath = & $VSWhere -latest -products * -requires Microsoft.Component.MSBuild -find 'MSBuild\**\Bin\MSBuild.exe' | Select-Object -First 1
+			if ( $MSBuildPath ) {
+				$MSBuild = Get-Command $MSBuildPath -ErrorAction SilentlyContinue
+			}
+		}
+	}
+
+	if ( -Not $MSBuild ) {
+		Write-Error 'MSBuild was not found. Install Visual Studio Build Tools or run microsoft/setup-msbuild before build.ps1.'
+		exit 1
+	}
+
+	& $MSBuild.Path `
+		-property:Configuration=$Configuration `
+		-property:Platform=x64 `
+		$Project
+}
+
 if ( Test-Path -Path $OutputPath ) {
     rm -Recurse -Force $OutputPath
 }
@@ -76,10 +105,7 @@ if ( -Not ( Test-Path ".\Redirector\bin\$Configuration" ) ) {
 	Write-Host
 	Write-Host 'Building Redirector'
 
-	msbuild `
-		-property:Configuration=$Configuration `
-		-property:Platform=x64 `
-		'.\Redirector\Redirector.vcxproj'
+	Invoke-MSBuild '.\Redirector\Redirector.vcxproj'
 	if ( -Not $? ) { exit $lastExitCode }
 }
 cp -Force ".\Redirector\bin\$Configuration\nfapi.dll"      "$OutputPath\bin"
@@ -89,10 +115,7 @@ if ( -Not ( Test-Path ".\RouteHelper\bin\$Configuration" ) ) {
 	Write-Host
 	Write-Host 'Building RouteHelper'
 
-	msbuild `
-		-property:Configuration=$Configuration `
-		-property:Platform=x64 `
-		'.\RouteHelper\RouteHelper.vcxproj'
+	Invoke-MSBuild '.\RouteHelper\RouteHelper.vcxproj'
 	if ( -Not $? ) { exit $lastExitCode }
 }
 cp -Force ".\RouteHelper\bin\$Configuration\RouteHelper.bin" "$OutputPath\bin"


### PR DESCRIPTION
### Motivation
- CI 在构建 Redirector/RouteHelper 时出现 `msbuild` 未被识别的错误，Release workflow 也缺少设置 MSBuild 的步骤，导致整体构建失败。 
- 原脚本中对 `msbuild` 的直接调用在本地或 CI 环境可能找不到可执行文件且错误信息不明确，需要兼容 PATH 与 Visual Studio 安装位置并给出友好提示。

### Description
- 将构建工作流的 MSBuild 步骤升级为 `microsoft/setup-msbuild@v2`，并在 Release workflow 中补上该步骤以确保 `build.ps1` 运行前已安装 MSBuild。 
- 在 `build.ps1` 中新增 `Invoke-MSBuild` 函数，函数会先从 `PATH` 查找 `msbuild`，找不到时使用 `vswhere.exe` 搜索 Visual Studio 安装中的 MSBuild，并在均未找到时输出明确错误后退出。 
- 把原先对 `msbuild` 的裸调用替换为统一的 `Invoke-MSBuild` 调用以构建 `Redirector` 和 `RouteHelper`。 
- 规范了 `build.ps1` 的编码/行尾（PowerShell 脚本保留 UTF-8 BOM，工作流文件使用 CRLF）以符合项目约定并消除行尾/空格检查问题。 

### Testing
- 运行了空白/行尾检查命令 `git -c core.whitespace=cr-at-eol diff --check` 并修正了检测到的问题，检查通过。 
- 在本地对修改的工作流和 `build.ps1` 做了语法/格式调整并提交变更，确保 CI 可顺序执行 `Setup MSBuild` 后调用 `build.ps1`（本次变更覆盖 CI 中导致构建失败的根因）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5cf7ee293c8322bfa5feecd378881f)